### PR TITLE
Remove "materialize" alias

### DIFF
--- a/config.js
+++ b/config.js
@@ -37,6 +37,7 @@ System.config({
     "es6-shim": "github:es-shims/es6-shim@0.35.1",
     "jquery": "npm:jquery@2.2.3",
     "materialize": "npm:materialize-css@0.97.6",
+    "materialize-css": "npm:materialize-css@0.97.6",
     "reflect-metadata": "npm:reflect-metadata@0.1.3",
     "rxjs": "npm:rxjs@5.0.0-beta.6",
     "typescript": "npm:typescript@1.8.10",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
       "css": "github:systemjs/plugin-css@^0.1.20",
       "es6-shim": "github:es-shims/es6-shim@^0.35.1",
       "jquery": "npm:jquery@^2.2.1",
-      "materialize": "npm:materialize-css@^0.97.5",
+      "materialize-css": "npm:materialize-css@^0.97.5",
       "reflect-metadata": "npm:reflect-metadata@^0.1.3",
       "rxjs": "npm:rxjs@5.0.0-beta.6",
       "typescript": "npm:typescript@^1.8.10",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import "materialize";
+import "materialize-css";
 
 // export {Materialize,MaterializeOptions} from "./materialize";
 export {MaterializeDirective} from "./materialize-directive";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,8 +8,7 @@ module.exports = {
     devtool: 'source-map',
     resolve: {
         alias: {
-          materializecss: 'materialize-css/dist/css/materialize.css',
-          materialize: 'materialize-css/dist/js/materialize.js',
+          "materialize-css": 'materialize-css/dist/css/materialize.css'
         },
         extensions: ['', '.webpack.js', '.web.js', '.ts', '.js', '.css']
     },
@@ -17,7 +16,7 @@ module.exports = {
         loaders: [
             {
               test: /materialize-css\/dist\/js\/materialize\.js/,
-              loader: 'imports?materializecss'
+              loader: 'imports?materialize-css'
             },
             { test: /\.ts$/, loader: 'ts-loader' },
             { test: /\.css$/, loader: 'style-loader!css-loader' },


### PR DESCRIPTION
This little PR just removes the "materialize" alias and uses the original "materialize-css" package name. This allows other build systems like Webpack to not need to create an alias for "materialize" and materialize-css can still load before everything else. I ran `npm run dist` and tested it locally in my angular-cli@webpack project and it works.