### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ npm install jquery@^2.2.4 --save
 add scripts in angular-cli.json
 ```
 "scripts": [
-  "../node_modules/jquery/dist/jquery.js",
+  "../node_modules/jquery/dist/jquery.min.js",
   "../node_modules/materialize-css/dist/js/materialize.js"
 ],
 ```


### PR DESCRIPTION
Change the scripts in the angular-cli.json file to point to the minified version of jQuery instead of the full version. This will prevent `TypeError: Cannot read property 'swing' of undefined`