### PR TITLE
feat(compilation): Add support for AoT compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ test/**/*.js.map
 
 !karma*.js
 !test/karma*.js
+
+/compiled
+*.metadata.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 jspm_packages
+/compiled

--- a/app/app.module.ts
+++ b/app/app.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { BrowserModule }  from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 import { LocationStrategy, HashLocationStrategy } from '@angular/common';
-import {MaterializeDirective} from "../src/index";
+import { MaterializeModule } from "../src/index";
 import {MaterialInput,
         Option,
         MaterialSelect} from "./components/model-bindings/index"
@@ -37,12 +37,12 @@ import { routing, appRoutingProviders } from './app.routing'
     SideNav,
     DatePicker,
     ModelBindings,
-    MaterializeDirective,
     MaterialInput,
     MaterialSelect,
 
   ],
   imports: [
+    MaterializeModule,
     BrowserModule,
     FormsModule,
     routing

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@ var gulp = require('gulp');
 var rimraf = require('gulp-rimraf');
 var runSequence = require('run-sequence');
 var tsc = require('gulp-typescript');
+var exec = require('child_process').exec;
 
 var paths = {
     dist: './dist',
@@ -25,6 +26,14 @@ gulp.task('tsc', function () {
     return tsResult.dts.pipe(gulp.dest(paths.dist));
 });
 
+gulp.task('ngc', function (cb) {
+  exec('ngc -p tsconfig-ngc.json', function(err, stdout, stderr) {
+    console.log(stdout);
+    console.log(stderr);
+    cb(err);
+  });
+});
+
 gulp.task('copy', function(){
     return gulp.src(paths.distSourcesFiles).pipe(gulp.dest(paths.dist));
 });
@@ -38,7 +47,7 @@ gulp.task('default', function (callback) {
     runSequence(
         'clean',
         'copySources',
-        'tsc',
+        'ngc',
         'copy',
         'cleanup',
         function (error) {

--- a/package.json
+++ b/package.json
@@ -46,10 +46,12 @@
   "devDependencies": {
     "@angular/common": "^2.1.2",
     "@angular/compiler": "^2.1.2",
+    "@angular/compiler-cli": "^2.1.2",
     "@angular/core": "^2.1.2",
     "@angular/platform-browser": "^2.1.2",
     "@angular/platform-browser-dynamic": "^2.1.2",
-    "@angular/router": "^3.0.0",
+    "@angular/platform-server": "^2.1.2",
+    "@angular/router": "^3.1.2",
     "commitizen": "^2.4.6",
     "css-loader": "^0.23.1",
     "cz-conventional-changelog": "^1.1.5",
@@ -76,7 +78,7 @@
     "ts-loader": "^0.8.1",
     "tsc": "^1.20150623.0",
     "tsd": "^0.6.5",
-    "typescript": "^1.8.10",
+    "typescript": "^2.0.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.14",
     "zone.js": "^0.6.25"

--- a/src/materialize-directive.ts
+++ b/src/materialize-directive.ts
@@ -49,7 +49,7 @@ export class MaterializeDirective implements AfterViewInit,DoCheck,OnChanges,OnD
     }
     @Input() set materializeActions(actions:EventEmitter<string|MaterializeAction>) {            
       actions.subscribe((action:string|MaterializeAction) => {
-        if (typeof action == "string") {
+        if (typeof action === "string") {
           this.performLocalElementUpdates(action);
         } else {
           this.performLocalElementUpdates(action.action,action.params);          
@@ -67,7 +67,7 @@ export class MaterializeDirective implements AfterViewInit,DoCheck,OnChanges,OnD
       this.performElementUpdates();
     }
 
-    public ngOnChanges() {
+    public ngOnChanges(_unused?) {
       if (this.isSelect()) {
         setTimeout(() => this.performLocalElementUpdates(), 10);
       }
@@ -130,7 +130,7 @@ export class MaterializeDirective implements AfterViewInit,DoCheck,OnChanges,OnD
         const nativeElement = this._el.nativeElement;
         const jQueryElement = $(nativeElement);
 
-        jQueryElement.on("change", e => nativeElement.dispatchEvent(new CustomEvent("input")));
+        jQueryElement.on("change", e => nativeElement.dispatchEvent(new (<any>CustomEvent("input"))));
       }
 
       if (this.isDatePicker()) {
@@ -139,7 +139,7 @@ export class MaterializeDirective implements AfterViewInit,DoCheck,OnChanges,OnD
         const enablebtns = this.enableDPButtons;
 
         jQueryElement[this._functionName](...this._params);
-        jQueryElement.on("change", e => nativeElement.dispatchEvent(new CustomEvent("input")));
+        jQueryElement.on("change", e => nativeElement.dispatchEvent(new (<any>CustomEvent("input"))));
         //jQueryElement.on("change", e => nativeElement.dispatchEvent(new Event("input")));
         // jQueryElement.on("change", e => dispatchEventOnTarget(nativeElement,"input"));
 

--- a/tsconfig-ngc.json
+++ b/tsconfig-ngc.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "removeComments": false,
+    "noImplicitAny": false,
+    "outDir": "dist",
+    "declaration": true
+  },
+  "files": [
+    "src/materialize-module.ts",
+    "src/materialize-directive.ts",
+    "src/custom-event-polyfill.ts",
+    "src/index.ts",
+    "node_modules/typescript/lib/lib.es6.d.ts"
+  ],
+  "angularCompilerOptions": {
+    "genDir": "compiled"
+  }
+}


### PR DESCRIPTION
So this should enable AoT compilation.

Caveats:
- I could not get it to build without typecasting `CustomEvent`s to `any`.
- There is no good equivalent to `gulp-typescript` for `ngc`, so I just spawn a shell instead.
- Since there is no good equivalent, `ngc` needs a seperate `tsconfig.json`

Do you use the `tsc` build outside of building for dist? That should probably also be migrated to `ngc` in order to make things more consistent. This might also enable a single `tsconfig.json`.

Let me know if there are any issues!

Fixes #145, #121