### PR TITLE
Address the textarea events missing on change

### DIFF
--- a/src/materialize-directive.ts
+++ b/src/materialize-directive.ts
@@ -22,8 +22,7 @@ declare var Materialize:any;
   // "characterCounter" |
   // "material_select" |
   // "sideNav" |
-  // "leanModal" |
-  // "textarea";
+  // "leanModal";
 
 export interface MaterializeAction {
   action:string;
@@ -248,7 +247,7 @@ export class MaterializeDirective implements AfterViewInit,DoCheck,OnChanges,OnD
     }
 
     private isTextarea() {
-        return (this._functionName && this._functionName === "textarea");
+        return this._el.nativeElement.nodeName == "TEXTAREA";
     }
 
     private enableDPButtons(){

--- a/src/materialize-directive.ts
+++ b/src/materialize-directive.ts
@@ -22,7 +22,8 @@ declare var Materialize:any;
   // "characterCounter" |
   // "material_select" |
   // "sideNav" |
-  // "leanModal";
+  // "leanModal" |
+  // "textarea";
 
 export interface MaterializeAction {
   action:string;
@@ -70,6 +71,9 @@ export class MaterializeDirective implements AfterViewInit,DoCheck,OnChanges,OnD
     public ngOnChanges(_unused?) {
       if (this.isSelect()) {
         setTimeout(() => this.performLocalElementUpdates(), 10);
+      }
+      else if (this.isTextarea()) {
+        setTimeout(() => this.performElementUpdates(), 10);
       }
     }
 
@@ -178,6 +182,10 @@ export class MaterializeDirective implements AfterViewInit,DoCheck,OnChanges,OnD
         });
       }
 
+      if (this.isTextarea()) {
+          this._el.nativeElement.dispatchEvent((<any>CustomEvent("autoresize", {bubbles: true, cancelable: false, detail: undefined})));
+      }
+
       this.performLocalElementUpdates();
     }
 
@@ -237,6 +245,10 @@ export class MaterializeDirective implements AfterViewInit,DoCheck,OnChanges,OnD
 
     private isAutocomplete() {
       return (this._functionName && this._functionName === "autocomplete");
+    }
+
+    private isTextarea() {
+        return (this._functionName && this._functionName === "textarea");
     }
 
     private enableDPButtons(){


### PR DESCRIPTION
As per http://materializecss.com/forms.html#textarea, events need to be triggered when a textarea's value is changed programmatically. 

Calls `Materialize.updateTextFields();` to trigger the label to update its 'active' class.
Triggers an 'autoresize' event to update the size of the textarea.

Address #163 #68 