### PR TITLE
fixed materialize-css version when install with npm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ For dynamic select elements apply the **materializeSelectOptions** directive to 
 
 Install MaterializeCSS and angular2-materialize from npm
 ```
-npm install materialize-css --save
+npm install materialize-css@0.98.2 --save
 npm install angular2-materialize --save
 ```
 


### PR DESCRIPTION
Currently. it is installed 0.99.0 version of materialize-css  if just type
```
npm install materialize-css --save
```
and then, type 

```
npm install angular2-materialize --save
```
it will get result of 

```
├── angular2-materialize@15.0.4 
└── UNMET PEER DEPENDENCY materialize-css@0.99.0
```

I don't know what can be happened if i just change materialize-css version 0.98.2 to 0.99.0 in this repo, so i just change readme.md file before you upgrade materialize-css version.