### PR TITLE
fix unexpected closing of multiselect dropdown

### DIFF
--- a/src/materialize-directive.ts
+++ b/src/materialize-directive.ts
@@ -89,7 +89,14 @@ export class MaterializeDirective implements AfterViewInit,DoCheck,OnChanges,OnD
 
     public ngOnChanges(_unused?) {
         if (this.isSelect()) {
-            setTimeout(() => this.performLocalElementUpdates(), 10);
+            const nativeElement = this._el.nativeElement;
+            const jQueryElement = $(nativeElement);
+            
+            // run performLocalElementUpdates() only if dropdown closed
+            // otherwise the dropdown closes unexpected
+            if (!jQueryElement.attr("multiple") || jQueryElement.parent().find("input.active").length === 0) {
+                setTimeout(() => this.performLocalElementUpdates(), 10);
+            }
         }
     }
 


### PR DESCRIPTION
This modification should prevent the multiselect-dropdown from being closed unexpected after clicking on one of the options.

The issue is described here: #370 
