### PR TITLE
In MaterializeAction replace [any] by any[]

### DIFF
--- a/src/materialize-directive.ts
+++ b/src/materialize-directive.ts
@@ -37,7 +37,7 @@ export interface MaterializeAction {
 })
 export class MaterializeDirective implements AfterViewInit,DoCheck,OnChanges,OnDestroy {
 
-    private _params: [any] = null;
+    private _params: any[] = null;
     private _functionName: string = null;
     private previousValue = null;
     private previousDisabled = false;

--- a/src/materialize-directive.ts
+++ b/src/materialize-directive.ts
@@ -29,7 +29,7 @@ declare var Materialize: any;
 
 export interface MaterializeAction {
     action: string;
-    params: [any];
+    params: any[];
 }
 
 @Directive({


### PR DESCRIPTION
Changing parameters type in MaterializeAction 
From [any] to any[].

[any] only has 1 element in its array.
any[] can has multiple elements. 

These are not equivalent.

Changing to any[] allows things like 
this.tabsActions.emit({action: "tabs", params: ['select_tab', page]}); that several persons were looking for, and it's compatible with previous versions.